### PR TITLE
Allow missing first_name field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # temporal_notifications
 temporal con notificaciones (Patrimore)
+
+## Frontend de ejemplo
+
+Se incluye el archivo `frontend_example.html` que muestra de manera sencilla los
+usuarios con datos faltantes registrados en `server_notifications`. Solo abre el
+archivo en tu navegador y se listarán los pendientes obtenidos desde
+`http://localhost:9000/pending`. Desde ahí puedes seleccionar un usuario y
+completar la información requerida.

--- a/frontend_example.html
+++ b/frontend_example.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Completar Datos Pendientes</title>
+    <script>
+    async function loadPending(){
+        const res = await fetch('http://localhost:9000/pending');
+        const html = await res.text();
+        document.getElementById('pending').innerHTML = html;
+    }
+    window.onload = loadPending;
+    </script>
+</head>
+<body>
+<h2>Usuarios con datos faltantes</h2>
+<div id="pending">Cargando...</div>
+<p>Selecciona un usuario para completar sus datos. Se abrirá un formulario donde podrás enviar la información de vuelta al flujo.</p>
+</body>
+</html>

--- a/models.py
+++ b/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 @dataclass
 class User:
-    first_name: str
+    first_name: Optional[str]
     last_name: Optional[str]
     rut: str
     address: str
@@ -56,7 +56,7 @@ class User:
         )
 
 class UserModel(BaseModel):
-    first_name: str
+    first_name: Optional[str] = None
     last_name: Optional[str] = None
     rut: str
     address: str


### PR DESCRIPTION
## Summary
- allow `first_name` to be optional so incomplete payloads are accepted
- document a small example frontend page
- add a simple HTML page that lists pending users

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c2d6b10dc83338531c11081e4b45c