### PR TITLE
Handle signal using dict

### DIFF
--- a/server.py
+++ b/server.py
@@ -42,13 +42,11 @@ async def receive_user(
     if not isinstance(user_dict.get('created_at'), str):
         user_dict['created_at'] = datetime.now().isoformat()
 
-    # Convertir payload a dataclass
-    user = User(**user_dict)
-
     # Obtener handle al workflow en ejecución
     handle = client.get_workflow_handle("user-listener")
-    # Enviar señal 'submit' al workflow
-    await handle.signal("submit", user)
+    # Enviar señal 'submit' al workflow con el dict en vez de dataclass para
+    # evitar problemas de serialización entre distintas versiones de Python
+    await handle.signal("submit", user_dict)
     return {"status": "submitted"}
 
 if __name__ == "__main__":

--- a/workflows.py
+++ b/workflows.py
@@ -32,9 +32,12 @@ class UserWorkflow:
         self._waiting: Dict[str, workflow.Future] = {}
 
     @workflow.signal
-    async def submit(self, user: User) -> None:
+    async def submit(self, user_data: dict) -> None:
         """Señal para encolar un nuevo User."""
-        self._queue.append(user)
+        # Convertir los datos recibidos en una instancia de User. Recibimos un
+        # diccionario para evitar problemas de deserialización de dataclasses
+        # cuando la señal proviene de distintos entornos de Python.
+        self._queue.append(User(**user_data))
 
     @workflow.signal
     async def update(self, user_data: dict) -> None:


### PR DESCRIPTION
## Summary
- avoid dataclass serialization issues by sending a plain dict in `submit`
- convert dict to dataclass inside the workflow when receiving the signal

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c3477b5448333a04a17c806869420